### PR TITLE
resolve race condition on c2 startup

### DIFF
--- a/rabbitmq/initialize.go
+++ b/rabbitmq/initialize.go
@@ -82,6 +82,7 @@ func (r *rabbitMQConnection) startListeners(services []string) {
 			exclusiveQueue,
 			&wg)
 	}
+	wg.Wait()
 	// handle starting any queues that are necessary for a logging container
 	if utils.StringSliceContains(services, "logger") {
 		logging.LogInfo("Initializing RabbitMQ for SIEM Logging Services")

--- a/rabbitmq/utils.go
+++ b/rabbitmq/utils.go
@@ -219,11 +219,6 @@ func (r *rabbitMQConnection) ReceiveFromMythicDirectExchange(exchange string, qu
 	// queue is where the messages get sent to (local name)
 	// routingKey is the specific direct topic we're interested in for the exchange
 	// handler processes the messages we get on our queue
-	defer func() {
-		if wg != nil {
-			wg.Done()
-		}
-	}()
 	for {
 		if conn, err := r.GetConnection(); err != nil {
 			logging.LogError(err, "Failed to connect to rabbitmq", "retry_wait_time", RETRY_CONNECT_DELAY)
@@ -288,6 +283,10 @@ func (r *rabbitMQConnection) ReceiveFromMythicDirectExchange(exchange string, qu
 				forever <- true
 			}()
 			logging.LogInfo("Started listening for messages", "exchange", exchange, "queue", queue, "routingKey", routingKey)
+			if wg != nil {
+				wg.Done()
+				wg = nil
+			}
 			<-forever
 			ch.Close()
 			logging.LogError(nil, "Stopped listening for messages", "exchange", exchange, "queue", queue, "routingKey", routingKey)
@@ -296,11 +295,6 @@ func (r *rabbitMQConnection) ReceiveFromMythicDirectExchange(exchange string, qu
 	}
 }
 func (r *rabbitMQConnection) ReceiveFromRPCQueue(exchange string, queue string, routingKey string, handler RPCQueueHandler, exclusiveQueue bool, wg *sync.WaitGroup) {
-	defer func() {
-		if wg != nil {
-			wg.Done()
-		}
-	}()
 	for {
 		if conn, err := r.GetConnection(); err != nil {
 			logging.LogError(err, "Failed to connect to rabbitmq", "retry_wait_time", RETRY_CONNECT_DELAY)
@@ -383,6 +377,10 @@ func (r *rabbitMQConnection) ReceiveFromRPCQueue(exchange string, queue string, 
 				forever <- true
 			}()
 			logging.LogInfo("Started listening for rpc messages", "exchange", exchange, "queue", queue, "routingKey", routingKey)
+			if wg != nil {
+				wg.Done()
+				wg = nil
+			}
 			<-forever
 			ch.Close()
 			logging.LogError(nil, "Stopped listening for messages", "exchange", exchange, "queue", queue, "routingKey", routingKey)


### PR DESCRIPTION
After starting gorutines to setup handlers on RPC calls, called SyncC2 function which triggers C2 Profile startup before goroutine setup handler on RabbitMq queue for it. Due to it Profile isn`t started automatically by Mythic server.