### PR TITLE
Refactor Mythic configuration variables to separate package

### DIFF
--- a/agent_structs/utils.go
+++ b/agent_structs/utils.go
@@ -4,14 +4,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/MythicMeta/MythicContainer/logging"
-	"github.com/MythicMeta/MythicContainer/utils"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
 	"sync"
+
+	"github.com/MythicMeta/MythicContainer/logging"
+	"github.com/MythicMeta/MythicContainer/utils"
 )
 
 type RabbitmqRPCMethod struct {
@@ -131,7 +131,7 @@ func (r *allPayloadData) AddIcon(filePath string) {
 			r.payloadDefinition.AgentIcon = nil
 			logging.LogError(err, "Failed to open file path for agent icon")
 			os.Exit(1)
-		} else if agentIcon, err := ioutil.ReadAll(file); err != nil {
+		} else if agentIcon, err := io.ReadAll(file); err != nil {
 			r.payloadDefinition.AgentIcon = nil
 			logging.LogError(err, "Failed to read agent icon")
 			os.Exit(1)

--- a/config/config.go
+++ b/config/config.go
@@ -1,10 +1,11 @@
-package utils
+package config
 
 import (
 	"log"
 	"os"
 	"path/filepath"
 
+	"github.com/MythicMeta/MythicContainer/utils"
 	"github.com/spf13/viper"
 )
 
@@ -58,10 +59,10 @@ func init() {
 	// pull in environment variables and configuration from .env if needed
 	mythicEnv.SetConfigName(".env")
 	mythicEnv.SetConfigType("env")
-	mythicEnv.AddConfigPath(getCwdFromExe())
+	mythicEnv.AddConfigPath(utils.GetCwdFromExe())
 	mythicEnv.AutomaticEnv()
-	if !fileExists(filepath.Join(getCwdFromExe(), ".env")) {
-		_, err := os.Create(filepath.Join(getCwdFromExe(), ".env"))
+	if !utils.FileExists(filepath.Join(utils.GetCwdFromExe(), ".env")) {
+		_, err := os.Create(filepath.Join(utils.GetCwdFromExe(), ".env"))
 		if err != nil {
 			log.Fatalf("[-] .env doesn't exist and couldn't be created: %v", err)
 		}
@@ -100,22 +101,4 @@ func setConfigFromEnv(mythicEnv *viper.Viper) {
 	MythicConfig.WebhookStartupChannel = mythicEnv.GetString("webhook_default_startup_channel")
 	MythicConfig.WebhookAlertChannel = mythicEnv.GetString("webhook_default_alert_channel")
 	MythicConfig.WebhookCustomChannel = mythicEnv.GetString("webhook_default_custom_channel")
-}
-
-func getCwdFromExe() string {
-	exe, err := os.Executable()
-	if err != nil {
-		log.Fatalf("[-] Failed to get path to current executable: %v", err)
-	}
-	return filepath.Dir(exe)
-}
-
-func fileExists(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false
-		}
-	}
-	return !info.IsDir()
 }

--- a/grpc/initialize.go
+++ b/grpc/initialize.go
@@ -5,16 +5,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/MythicMeta/MythicContainer/grpc/services"
-	"github.com/MythicMeta/MythicContainer/logging"
-	"github.com/MythicMeta/MythicContainer/translationstructs"
-	"github.com/MythicMeta/MythicContainer/utils"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"io"
 	"math"
 	"sync"
 	"time"
+
+	"github.com/MythicMeta/MythicContainer/config"
+	"github.com/MythicMeta/MythicContainer/grpc/services"
+	"github.com/MythicMeta/MythicContainer/logging"
+	"github.com/MythicMeta/MythicContainer/translationstructs"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const grpcReconnectDelay = 5 * time.Second
@@ -24,7 +25,7 @@ func Initialize(translationContainerName string) {
 	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt)))
 	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(math.MaxInt)))
-	connectionString := fmt.Sprintf("%s:%d", utils.MythicConfig.MythicServerHost, utils.MythicConfig.MythicServerGRPCPort)
+	connectionString := fmt.Sprintf("%s:%d", config.MythicConfig.MythicServerHost, config.MythicConfig.MythicServerGRPCPort)
 	for {
 		logging.LogDebug("Attempting to connect to grpc...")
 		if conn, err := grpc.Dial(connectionString, opts...); err != nil {

--- a/grpc/pushC2.go
+++ b/grpc/pushC2.go
@@ -2,12 +2,13 @@ package grpc
 
 import (
 	"fmt"
-	"github.com/MythicMeta/MythicContainer/logging"
-	"github.com/MythicMeta/MythicContainer/utils"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"math"
 	"time"
+
+	"github.com/MythicMeta/MythicContainer/config"
+	"github.com/MythicMeta/MythicContainer/logging"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func GetNewPushC2ClientConnection() *grpc.ClientConn {
@@ -15,7 +16,7 @@ func GetNewPushC2ClientConnection() *grpc.ClientConn {
 	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt)))
 	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(math.MaxInt)))
-	connectionString := fmt.Sprintf("%s:%d", utils.MythicConfig.MythicServerHost, utils.MythicConfig.MythicServerGRPCPort)
+	connectionString := fmt.Sprintf("%s:%d", config.MythicConfig.MythicServerHost, config.MythicConfig.MythicServerGRPCPort)
 	for {
 		logging.LogDebug("Attempting to connect to grpc...")
 		if conn, err := grpc.Dial(connectionString, opts...); err != nil {

--- a/logging/initialize.go
+++ b/logging/initialize.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/MythicMeta/MythicContainer/utils"
+	"github.com/MythicMeta/MythicContainer/config"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zerologr"
 	"github.com/rs/zerolog"
@@ -20,7 +20,7 @@ func init() {
 	zerologr.NameFieldName = "logger"
 	zerologr.NameSeparator = "/"
 	var zl zerolog.Logger
-	switch utils.MythicConfig.DebugLevel {
+	switch config.MythicConfig.DebugLevel {
 	case "warning":
 		zl = zerolog.New(os.Stdout).Level(zerolog.WarnLevel)
 	case "info":

--- a/mythicrpc/utils_send_file_to_mythic.go
+++ b/mythicrpc/utils_send_file_to_mythic.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/MythicMeta/MythicContainer/logging"
-	"github.com/MythicMeta/MythicContainer/utils"
 	"io"
 	"mime/multipart"
 	"net/http"
+
+	"github.com/MythicMeta/MythicContainer/config"
+	"github.com/MythicMeta/MythicContainer/logging"
 )
 
 func sendFileToMythic(content *[]byte, fileID string) error {
@@ -29,8 +30,8 @@ func sendFileToMythic(content *[]byte, fileID string) error {
 	}
 	writer.Close()
 	if request, err := http.NewRequest("POST",
-		fmt.Sprintf("http://%s:%d/direct/upload/%s", utils.MythicConfig.MythicServerHost,
-			utils.MythicConfig.MythicServerPort, fileID), body); err != nil {
+		fmt.Sprintf("http://%s:%d/direct/upload/%s", config.MythicConfig.MythicServerHost,
+			config.MythicConfig.MythicServerPort, fileID), body); err != nil {
 		logging.LogError(err, "Failed to create new POST request to send payload to Mythic")
 		return err
 	} else {
@@ -51,8 +52,8 @@ func sendFileToMythic(content *[]byte, fileID string) error {
 }
 func getFileFromMythic(fileID string) (*[]byte, error) {
 	if request, err := http.NewRequest("GET",
-		fmt.Sprintf("http://%s:%d/direct/download/%s", utils.MythicConfig.MythicServerHost,
-			utils.MythicConfig.MythicServerPort, fileID), nil); err != nil {
+		fmt.Sprintf("http://%s:%d/direct/download/%s", config.MythicConfig.MythicServerHost,
+			config.MythicConfig.MythicServerPort, fileID), nil); err != nil {
 		logging.LogError(err, "Failed to create new GET request to get file from Mythic")
 		return nil, err
 	} else {

--- a/rabbitmq/recv_c2_rpc_get_file.go
+++ b/rabbitmq/recv_c2_rpc_get_file.go
@@ -3,11 +3,12 @@ package rabbitmq
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/MythicMeta/MythicContainer/c2_structs"
-	"github.com/MythicMeta/MythicContainer/logging"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
+
+	c2structs "github.com/MythicMeta/MythicContainer/c2_structs"
+	"github.com/MythicMeta/MythicContainer/logging"
 )
 
 // Register this RPC method with rabbitmq so it can be called
@@ -40,7 +41,7 @@ func C2RPCGetFile(input c2structs.C2RPCGetFileMessage) c2structs.C2RPCGetFileMes
 		responseMsg.Error = fmt.Sprintf("Failed to locate file: %s\n", err.Error())
 	} else if file, err := os.Open(filePath); err != nil {
 		responseMsg.Error = fmt.Sprintf("Failed to open file: %s", err.Error())
-	} else if contents, err := ioutil.ReadAll(file); err != nil {
+	} else if contents, err := io.ReadAll(file); err != nil {
 		responseMsg.Error = fmt.Sprintf("Failed to read file: %s", err.Error())
 	} else {
 		responseMsg.Success = true

--- a/rabbitmq/utils.go
+++ b/rabbitmq/utils.go
@@ -16,8 +16,8 @@ import (
 	"github.com/google/uuid"
 
 	agentstructs "github.com/MythicMeta/MythicContainer/agent_structs"
+	"github.com/MythicMeta/MythicContainer/config"
 	"github.com/MythicMeta/MythicContainer/logging"
-	"github.com/MythicMeta/MythicContainer/utils"
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
@@ -32,11 +32,11 @@ func (r *rabbitMQConnection) GetConnection() (*amqp.Connection, error) {
 		for {
 			logging.LogInfo("Attempting to connect to rabbitmq")
 			conn, err := amqp.DialConfig(fmt.Sprintf("amqp://%s:%s@%s:%d/%s",
-				utils.MythicConfig.RabbitmqUser,
-				utils.MythicConfig.RabbitmqPassword,
-				utils.MythicConfig.RabbitmqHost,
-				utils.MythicConfig.RabbitmqPort,
-				utils.MythicConfig.RabbitmqVHost),
+				config.MythicConfig.RabbitmqUser,
+				config.MythicConfig.RabbitmqPassword,
+				config.MythicConfig.RabbitmqHost,
+				config.MythicConfig.RabbitmqPort,
+				config.MythicConfig.RabbitmqVHost),
 				amqp.Config{
 					Dial: func(network, addr string) (net.Conn, error) {
 						return net.DialTimeout(network, addr, 10*time.Second)
@@ -588,7 +588,7 @@ func UploadPayloadData(payloadBuildMsg agentstructs.PayloadBuildMessage, payload
 		return err
 	}
 	writer.Close()
-	if request, err := http.NewRequest("POST", fmt.Sprintf("http://%s:%d/direct/upload/%s", utils.MythicConfig.MythicServerHost, utils.MythicConfig.MythicServerPort, payloadBuildMsg.PayloadFileUUID), body); err != nil {
+	if request, err := http.NewRequest("POST", fmt.Sprintf("http://%s:%d/direct/upload/%s", config.MythicConfig.MythicServerHost, config.MythicConfig.MythicServerPort, payloadBuildMsg.PayloadFileUUID), body); err != nil {
 		logging.LogError(err, "Failed to create new POST request to send payload to Mythic")
 		return err
 	} else {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,5 +1,11 @@
 package utils
 
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
 func StringSliceContains(source []string, str string) bool {
 	for _, v := range source {
 		if str == v {
@@ -20,4 +26,22 @@ func RemoveStringFromSliceNoOrder(source []string, str string) []string {
 	}
 	// we didn't find the element to remove
 	return source
+}
+
+func GetCwdFromExe() string {
+	exe, err := os.Executable()
+	if err != nil {
+		log.Fatalf("[-] Failed to get path to current executable: %v", err)
+	}
+	return filepath.Dir(exe)
+}
+
+func FileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return !info.IsDir()
 }

--- a/webhookstructs/utils.go
+++ b/webhookstructs/utils.go
@@ -5,12 +5,14 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/MythicMeta/MythicContainer/logging"
-	"github.com/MythicMeta/MythicContainer/utils"
 	"io"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/MythicMeta/MythicContainer/config"
+	"github.com/MythicMeta/MythicContainer/logging"
+	"github.com/MythicMeta/MythicContainer/utils"
 )
 
 const EMIT_WEBHOOK_ROUTING_KEY_PREFIX = "emit_webhook"
@@ -149,8 +151,8 @@ func (r *allWebhookData) GetWebhookURL(input interface{}, channelType WEBHOOK_TY
 	default:
 	}
 	// allow the environment to override the program definition
-	if utils.MythicConfig.WebhookDefaultURL != "" {
-		return utils.MythicConfig.WebhookDefaultURL
+	if config.MythicConfig.WebhookDefaultURL != "" {
+		return config.MythicConfig.WebhookDefaultURL
 	} else {
 		return r.webhookDefinition.WebhookURL
 	}
@@ -164,44 +166,44 @@ func (r *allWebhookData) GetWebhookChannel(input interface{}, channelType WEBHOO
 	switch channelType {
 	case WEBHOOK_TYPE_NEW_FEEDBACK:
 		msg := input.(NewFeedbackWebookMessage)
-		if utils.MythicConfig.WebhookFeedbackChannel != "" {
-			return utils.MythicConfig.WebhookFeedbackChannel
+		if config.MythicConfig.WebhookFeedbackChannel != "" {
+			return config.MythicConfig.WebhookFeedbackChannel
 		} else if msg.OperationChannel != "" {
 			return msg.OperationChannel
 		}
 	case WEBHOOK_TYPE_NEW_CALLBACK:
 		msg := input.(NewCallbackWebookMessage)
-		if utils.MythicConfig.WebhookCallbackChannel != "" {
-			return utils.MythicConfig.WebhookCallbackChannel
+		if config.MythicConfig.WebhookCallbackChannel != "" {
+			return config.MythicConfig.WebhookCallbackChannel
 		} else if msg.OperationChannel != "" {
 			return msg.OperationChannel
 		}
 	case WEBHOOK_TYPE_NEW_STARTUP:
 		msg := input.(NewStartupWebhookMessage)
-		if utils.MythicConfig.WebhookStartupChannel != "" {
-			return utils.MythicConfig.WebhookStartupChannel
+		if config.MythicConfig.WebhookStartupChannel != "" {
+			return config.MythicConfig.WebhookStartupChannel
 		} else if msg.OperationChannel != "" {
 			return msg.OperationChannel
 		}
 	case WEBHOOK_TYPE_NEW_ALERT:
 		msg := input.(NewAlertWebhookMessage)
-		if utils.MythicConfig.WebhookAlertChannel != "" {
-			return utils.MythicConfig.WebhookAlertChannel
+		if config.MythicConfig.WebhookAlertChannel != "" {
+			return config.MythicConfig.WebhookAlertChannel
 		} else if msg.OperationChannel != "" {
 			return msg.OperationChannel
 		}
 	case WEBHOOK_TYPE_NEW_CUSTOM:
 		msg := input.(NewCustomWebhookMessage)
-		if utils.MythicConfig.WebhookCustomChannel != "" {
-			return utils.MythicConfig.WebhookCustomChannel
+		if config.MythicConfig.WebhookCustomChannel != "" {
+			return config.MythicConfig.WebhookCustomChannel
 		} else if msg.OperationChannel != "" {
 			return msg.OperationChannel
 		}
 	default:
 		logging.LogError(nil, "unknown webhook type when getting webhook channel", "type", channelType)
 	}
-	if utils.MythicConfig.WebhookDefaultChannel != "" {
-		return utils.MythicConfig.WebhookDefaultChannel
+	if config.MythicConfig.WebhookDefaultChannel != "" {
+		return config.MythicConfig.WebhookDefaultChannel
 	} else {
 		return r.webhookDefinition.WebhookChannel
 	}


### PR DESCRIPTION
Moves the Mythic container configuration from `utils` to a separate package. The `utils` package mainly consists of helper functions which do not rely on the Mythic configuration variables to be set.

Also removes all uses of the `ioutil` standard library package since it was deprecated in Go 1.16.