### PR TITLE
Fix the return type of SendMythicRPCCallbackSearch

### DIFF
--- a/mythicrpc/send_mythic_rpc_callback_search.go
+++ b/mythicrpc/send_mythic_rpc_callback_search.go
@@ -80,8 +80,8 @@ type MythicRPCCallbackSearchMessageResponse struct {
 	Results []MythicRPCCallbackSearchMessageResult `json:"results"`
 }
 
-func SendMythicRPCCallbackSearch(input MythicRPCCallbackSearchMessage) (*MythicRPCCallbackRemoveCommandMessageResponse, error) {
-	response := MythicRPCCallbackRemoveCommandMessageResponse{}
+func SendMythicRPCCallbackSearch(input MythicRPCCallbackSearchMessage) (*MythicRPCCallbackSearchMessageResponse, error) {
+	response := MythicRPCCallbackSearchMessageResponse{}
 	if responseBytes, err := rabbitmq.RabbitMQConnection.SendRPCStructMessage(
 		rabbitmq.MYTHIC_EXCHANGE,
 		rabbitmq.MYTHIC_RPC_CALLBACK_SEARCH,


### PR DESCRIPTION
Changes the return type of `SendMythicRPCCallbackSearch` from `MythicRPCCallbackRemoveCommandMessageResponse` to `MythicRPCCallbackSearchMessageResponse`.